### PR TITLE
Add serialization support to logger instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
             - ~/.m2
       - run: lein check
       - run: lein test
+      - run:
+          name: "Check logger serialization"
+          command: ./test/check-logger-serialization.sh
 
   coverage:
     executor: clojure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Ensure that dialog is initialized when events are logged. This fixes
   standalone usage without SLF4J.
+- Logger instances are now serializable, to support cases where a class being
+  serialized declares a non-static logger field.
 
 
 ## 0.1.0 - 2021-12-29

--- a/src/java/dialog/logger/DialogLogger.java
+++ b/src/java/dialog/logger/DialogLogger.java
@@ -4,6 +4,12 @@ import clojure.lang.IFn;
 import clojure.lang.Keyword;
 import clojure.lang.RT;
 import clojure.lang.Symbol;
+import clojure.lang.Var;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -12,7 +18,7 @@ import org.slf4j.Marker;
 /**
  * Logger interface for integrating with SLF4J.
  */
-public final class DialogLogger implements Logger {
+public final class DialogLogger implements Serializable, Logger {
 
     /**
      * Global version counter indicating that levels may have changed.
@@ -62,6 +68,35 @@ public final class DialogLogger implements Logger {
         this.getLevelFn = getLevelFn;
         this.logMessageFn = logMessageFn;
         this.cachedAt = -1;
+    }
+
+
+    ///// Serialization /////
+
+    /**
+     * Serialize this logger to an output stream.
+     *
+     * @param out  output stream to write to
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+
+    /**
+     * Deserialize a logger from an input stream.
+     *
+     * @param in  input stream to read from
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        IFn require = RT.var("clojure.core", "require");
+        Symbol loggerNS = Symbol.intern("dialog.logger");
+
+        synchronized (RT.REQUIRE_LOCK) {
+            require.invoke(loggerNS);
+        }
+
+        in.defaultReadObject();
     }
 
 

--- a/test/check-logger-serialization.sh
+++ b/test/check-logger-serialization.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Check that instances of the `dialog.logger.DialogLogger` class serialize
+# correctly.
+
+set -eo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+readonly TEST_DIR="target/test"
+readonly TEST_OBJ="$TEST_DIR/logger.object"
+readonly TEST_LOG="$TEST_DIR/out.log"
+
+rm -rf $TEST_DIR
+mkdir -p $TEST_DIR
+
+echo "Writing dialog config..."
+mkdir -p target/classes
+cat > target/classes/dialog.edn <<EOF
+{:outputs {:file {:type :file, :path "$TEST_LOG"}}}
+EOF
+
+echo "Building classpath..."
+readonly CLASSPATH="$(lein classpath 2> /dev/null)"
+
+echo "Compiling classes..."
+java -cp "$CLASSPATH" clojure.main - <<EOF
+(binding [*compile-path* "target/classes"]
+  (compile 'dialog.logger))
+EOF
+
+echo "Serializing logger..."
+java -cp "$CLASSPATH" clojure.main - <<EOF
+(require '[clojure.java.io :as io])
+
+(def logger (org.slf4j.LoggerFactory/getLogger "foo.bar.baz"))
+
+(.info logger "Hello, test")
+
+(with-open [out (java.io.ObjectOutputStream. (io/output-stream (io/file "$TEST_OBJ")))]
+  (.writeObject out logger))
+
+(System/exit 0)
+EOF
+
+echo "Checking files..."
+ls -l $TEST_DIR
+
+if [[ ! -f "$TEST_LOG" ]]; then
+    echo "Log output file $TEST_LOG not found!" >&2
+    exit 2
+fi
+
+if [[ ! -f "$TEST_OBJ" ]]; then
+    echo "Serialized logger object $TEST_OBJ not found!" >&2
+    exit 2
+fi
+
+readonly FIRST_LOG="$(cat "$TEST_LOG")"
+rm "$TEST_LOG"
+
+echo "Deserializing logger..."
+java -cp "$CLASSPATH" clojure.main - <<EOF
+(require '[clojure.java.io :as io])
+
+(with-open [in (java.io.ObjectInputStream. (io/input-stream (io/file "$TEST_OBJ")))]
+  (def logger (.readObject in)))
+
+(.info logger "Hello, test")
+
+(System/exit 0)
+EOF
+
+if [[ ! -f "$TEST_LOG" ]]; then
+    echo "Log output file $TEST_LOG not found!" >&2
+    exit 2
+fi
+
+echo "Comparing log outputs..."
+diff -u <(cut -d ' ' -f 2- <<<"$FIRST_LOG") <(cut -d ' ' -f 2- < "$TEST_LOG")


### PR DESCRIPTION
Switching to Dialog broke a test in one of our spark job projects, because a third-party library declares a non-static logger field:
```
Caused by: java.io.NotSerializableException: dialog.logger.DialogLogger
Serialization stack:
	- object not serializable (class: dialog.logger.DialogLogger, value: dialog.logger.DialogLogger@69f2cff6)
	- field (class: com.databricks.spark.xml.parsers.StaxXmlParser$, name: logger, type: interface org.slf4j.Logger)
	- object (class com.databricks.spark.xml.parsers.StaxXmlParser$, com.databricks.spark.xml.parsers.StaxXmlParser$@d95b04e)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 4)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class com.databricks.spark.xml.parsers.StaxXmlParser$, functionalInterfaceMethod=scala/Function1.apply:(Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeStatic com/databricks/spark/xml/parsers/StaxXmlParser$.$anonfun$parse$6:(Lcom/databricks/spark/xml/parsers/StaxXmlParser$;Lorg/apache/spark/sql/types/StructType;Lcom/databricks/spark/xml/XmlOptions;Lscala/Function2;Lscala/collection/Iterator;)Lscala/collection/Iterator;, instantiatedMethodType=(Lscala/collection/Iterator;)Lscala/collection/Iterator;, numCaptured=4])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class com.databricks.spark.xml.parsers.StaxXmlParser$$$Lambda$2960/954997812
```
To fix this, make `DialogLogger` instances serializable by ensuring that the supporting `dialog.logger` Clojure code is loaded before the instance fields are deserialized.