### PR TITLE
Add support for output-specific middleware functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- Add support for output-specific middleware.
 
 
 ## [0.2.0] - 2022-01-14

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ function should return an updated event if logging should proceed, or nil if
 the event should be dropped. A middleware call which throws an exception will
 be ignored, and the original event will continue being processed.
 
+Top-level middleware will be applied to all events; middleware may also be
+applied to individual outputs for more specific processing.
+
 ### Event Outputs
 
 Finally, dialog needs to know how and where to send the logged events. These

--- a/dev/dialog.edn
+++ b/dev/dialog.edn
@@ -51,4 +51,5 @@
                            :format :simple
                            :padding false}
                   :loggly {:type :syslog
-                           :format :json}}}}
+                           :format :json
+                           :middleware [acme.logging/filter-syslog]}}}}

--- a/src/clojure/dialog/config.clj
+++ b/src/clojure/dialog/config.clj
@@ -199,9 +199,10 @@
       :else
       (try
         (let [output (merge {:format :simple} output)]
-          [id (assoc output
-                     :formatter (output-formatter output)
-                     :writer (output-writer output))])
+          [id (-> output
+                  (resolve-middleware)
+                  (assoc :formatter (output-formatter output)
+                         :writer (output-writer output)))])
         (catch Exception ex
           (print-err "output %s could not be initialized: %s %s"
                      id

--- a/src/clojure/dialog/logger.clj
+++ b/src/clojure/dialog/logger.clj
@@ -244,7 +244,8 @@
     (run!
       (fn write-event
         [[id output]]
-        (write-output! id output event))
+        (when-let [event (apply-middleware event (:middleware output))]
+          (write-output! id output event)))
       (:outputs config))))
 
 


### PR DESCRIPTION
We've found a need to support logic on a per-output basis. This is an unfortunate increase in surface area, but this is the simplest way to allow the kind of extension we need, and provides the most flexibility for the least additional complexity.