### PR TITLE
Improve safety of JSON output writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add support for output-specific middleware.
 
+### Changed
+- The JSON formatter is much more defensive about unknown types and will
+  default to stringifying them when found.
+
 
 ## [0.2.0] - 2022-01-14
 

--- a/README.md
+++ b/README.md
@@ -176,10 +176,9 @@ There are four supported formats:
 - `:json`
 
   This renders the event data directly as JSON, which can be useful for outputs
-  which will be read by structured logging tools. This uses the Clojure
-  `data.json` library, so you can extend the `clojure.data.json/JSONWriter`
-  protocol if you need to support custom types. Alternately, transform them
-  with middleware before they are output.
+  which will be read by structured logging tools. If you need custom formatting
+  for certain types, you can transform them with middleware before they are
+  output.
 
 To support further light customization, both the `:simple` and `:pretty`
 formatters will look for some additional metadata on events:

--- a/test/dialog/format/json_test.clj
+++ b/test/dialog/format/json_test.clj
@@ -7,6 +7,16 @@
     java.time.Instant))
 
 
+(deftype Weird
+  [x]
+
+  Object
+
+  (toString
+    [_]
+    (str "<Weird:" x ">")))
+
+
 (deftest message-formatting
   (let [fmt (json/formatter {})]
     (testing "basic operation"
@@ -16,9 +26,20 @@
       (is (= "{\"time\":\"2021-12-27T15:17:31Z\"}"
              (fmt {:time (Instant/parse "2021-12-27T15:17:31Z")}))
           "instants format as strings"))
+    (testing "weird values"
+      (is (= "{\"nil\":null}"
+             (fmt {nil nil})))
+      (is (= "{\"wat\":\"<Weird:true>\"}"
+             (fmt {:wat (->Weird true)}))))
     (testing "namespaced keys"
       (is (= "{\"foo.bar/baz?\":true}"
              (fmt {:foo.bar/baz? true}))))
+    (testing "nested maps"
+      (is (= "{\"abc\":{\"def\":true}}"
+             (fmt {"abc" {"def" true}}))))
+    (testing "nested collections"
+      (is (= "{\"coll\":[\"def\",123,\"<Weird:abc>\"]}"
+             (fmt {'coll [:def 123 (->Weird "abc")]}))))
     (testing "throwables"
       (let [ex (RuntimeException. "BOOM")
             message (fmt {:error ex})]


### PR DESCRIPTION
Prior to this PR, the `:json` formatter relied on the `clojure.data.json/JSONWriter` protocol for writing values as a JSON strings. This works for the majority of cases, but fails in frustrating ways at runtime when an unsupported type sneaks into the logging data - the result is that the entire message fails to be logged. The error message itself is only notable if someone happens to look at the stderr of the process, which is also not great.

To fix this, instead of asking end-users to modify the (global!) extensions of the `JSONWriter` protocol, dialog itself is much more opinionated as to how log event data gets coerced before writing. This should result in unknown types falling back to `str` as a default encoder, and also means that `Exception` values _anywhere_ in the map will be properly rendered.