### PR TITLE
Dont shell out to get default hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- Remove shell call to `hostname` to infer the default computer hostname. This
+  caused the Clojure Agent send-off pool to be started at logging init time,
+  which was an unacceptable side-effect.
+
+### Added
+- The default hostname can now be modified with `dialog.util/set-hostname!` if
+  necessary.
 
 
 ## [0.3.1] - 2022-02-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Remove shell call to `hostname` to infer the default computer hostname. This
   caused the Clojure Agent send-off pool to be started at logging init time,
   which was an unacceptable side-effect.
+  [PR#8](https://github.com/amperity/dialog/pull/8)
 
 ### Added
 - The default hostname can now be modified with `dialog.util/set-hostname!` if

--- a/src/clojure/dialog/util.clj
+++ b/src/clojure/dialog/util.clj
@@ -1,5 +1,5 @@
 (ns ^:no-doc dialog.util
-  "Implemenation utilities."
+  "Implementation utilities."
   (:import
     java.net.InetAddress))
 

--- a/src/clojure/dialog/util.clj
+++ b/src/clojure/dialog/util.clj
@@ -1,8 +1,5 @@
 (ns ^:no-doc dialog.util
   "Implemenation utilities."
-  (:require
-    [clojure.java.shell :as sh]
-    [clojure.string :as str])
   (:import
     java.net.InetAddress))
 
@@ -67,25 +64,32 @@
 
 ;; ## Miscellaneous
 
-(let [hostname (delay
-                 (or (try
-                       (let [proc (sh/sh "hostname")]
-                         (when (zero? (:exit proc))
-                           (str/trim (:out proc))))
-                       (catch Exception ex
-                         (print-err :hostname
-                                    "Failed to resolve hostname with command: %s"
-                                    (ex-message ex))
-                         nil))
-                     (try
+(def ^:private hostname-ref
+  "A stateful reference to hold the current default hostname."
+  (atom nil))
+
+
+(defn set-hostname!
+  "Set the default hostname to use in log events. Returns nil."
+  [hostname]
+  (when-not (string? hostname)
+    (throw (IllegalArgumentException.
+             (str "Hostname must be a string, got a "
+                  (pr-str (class hostname))))))
+  (reset! hostname-ref hostname)
+  nil)
+
+
+(defn get-hostname
+  "Get the string name of the local host computer."
+  []
+  (or @hostname-ref
+      (let [hostname (try
                        (.getHostName (InetAddress/getLocalHost))
                        (catch Exception ex
                          (print-err :hostname
                                     "Failed to resolve hostname with InetAddress: %s"
                                     (ex-message ex))
-                         nil))
-                     "localhost"))]
-  (defn get-hostname
-    "Get the string name of the local host computer."
-    []
-    @hostname))
+                         "localhost"))]
+        (reset! hostname-ref hostname)
+        hostname)))


### PR DESCRIPTION
This is causing a super gnarly issue in our Spark code, due to the following chain of events:
- At init time, dialog would get loaded and wire itself up to SLF4J as the provider.
- The first log message would try to get the default host name: https://github.com/amperity/dialog/blob/69ccd2c6b4772d9a2f19098372026d98bd7eeb6c/src/clojure/dialog/logger.clj#L192-L193
- This would first try shelling out to `hostname` to get the canonical hostname in linux: https://github.com/amperity/dialog/blob/69ccd2c6b4772d9a2f19098372026d98bd7eeb6c/src/clojure/dialog/util.clj#L72
- This causes Clojure to spin up a couple of `future` threads to [handle the command IO](https://github.com/clojure/clojure/blob/clojure-1.10.3/src/clj/clojure/java/shell.clj#L125-L128).
- These threads get scheduled on the default `Agent/soloExecutor` [thread pool](https://github.com/clojure/clojure/blob/clojure-1.10.3/src/jvm/clojure/lang/Agent.java#L53-L54)
- Since these threads are being created at init time, they wind up inheriting the context `ClassLoader` from the base classloader in the JVM.
- However, when the Spark worker process runs an application, the dependencies in the app jar are downloaded at runtime, so it inserts a new `MutableURLClassLoader` as the [thread context when it launches the job](https://github.com/apache/spark/blob/v3.1.3/core/src/main/scala/org/apache/spark/deploy/worker/DriverWrapper.scala#L56-L60).
- This means code run in that thread (or descendants of that thread) works as expected, but **any code run on one of the threads started by dialog** would mysteriously fail to load classes that were only present in the app jar.

Shelling out in a logging library is probably undesirable even without these class loading shenanigans, so to address this I'm just going to remove the shell call and use the Java-native way of finding the current hostname. This includes a mutator method if clients really want to change the default value after the fact.