### PR TITLE
Fix root level property setting

### DIFF
--- a/src/clojure/dialog/config.clj
+++ b/src/clojure/dialog/config.clj
@@ -42,7 +42,7 @@
 
 
 (defn- collect-root-level
-  "Choose the dialog root logger level keyword by look at the environment and
+  "Choose the dialog root logger level keyword by looking at the environment and
   system properties."
   []
   (some->

--- a/src/clojure/dialog/config.clj
+++ b/src/clojure/dialog/config.clj
@@ -32,6 +32,27 @@
       default))
 
 
+(defn- select-profile
+  "Choose the dialog profile keyword by looking at the environment and system
+  properties."
+  []
+  (keyword (some-setting "DIALOG_PROFILE"
+                         "dialog.profile"
+                         :default)))
+
+
+(defn- collect-root-level
+  "Choose the dialog root logger level keyword by look at the environment and
+  system properties."
+  []
+  (some->
+    (some-setting "DIALOG_LEVEL"
+                  "dialog.level"
+                  nil)
+    (str/lower-case)
+    (keyword)))
+
+
 (defn- collect-prop-levels
   "Look in the JVM system properties for logger level configs. Returns a map of
   collected level settings."
@@ -236,12 +257,8 @@
   "Read logging configuration from an EDN resource (if available) and set any
   runtime overrides from JVM properties and the process environment."
   []
-  (let [profile (keyword (some-setting "DIALOG_PROFILE"
-                                       "dialog.profile"
-                                       :default))
-        root-level (some-setting "DIALOG_LEVEL"
-                                 "dialog.level"
-                                 nil)
+  (let [profile (select-profile)
+        root-level (collect-root-level)
         base-config (merge {:level :info
                             :outputs {:console :print}}
                            (read-config profile))]
@@ -252,7 +269,7 @@
               (collect-env-levels))
       (cond->
         (Level/isValid root-level)
-        (assoc :level (keyword root-level)))
+        (assoc :level root-level))
       (resolve-init)
       (apply-init)
       (resolve-middleware)


### PR DESCRIPTION
There's a bug when setting the level of the root logger via an environment or property override, which causes a `ClassCastException`:
```
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.Keyword
        at dialog.config$load_config.invokeStatic(config.clj:253)
        at dialog.config$load_config.invoke(config.clj:235)
        at dialog.logger$initialize_BANG_.invokeStatic(logger.clj:52)
        at dialog.logger$initialize_BANG_.invoke(logger.clj:49)
        at dialog.logger$log_event.invokeStatic(logger.clj:237)
        at dialog.logger$log_event.invoke(logger.clj:233)
```
This fixes the issue by coercing it to a keyword first.