### PR TITLE
Update to slf4j 2.0.3.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,9 +13,9 @@
   :dependencies
   [[org.clojure/clojure "1.11.1"]
    [org.clojure/data.json "2.4.0"]
-   [org.slf4j/slf4j-api "1.7.36"]
-   [org.slf4j/jul-to-slf4j "1.7.36"]
-   [org.slf4j/jcl-over-slf4j "1.7.36"]
+   [org.slf4j/slf4j-api "2.0.3"]
+   [org.slf4j/jul-to-slf4j "2.0.3"]
+   [org.slf4j/jcl-over-slf4j "2.0.3"]
    [io.aviso/pretty "1.1.1"]
    [aero "1.1.6"]]
 

--- a/src/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -24,7 +24,7 @@ public final class StaticLoggerBinder {
      *
      * This should be kept in sync with the version declared in `project.clj`.
      */
-    public static final String REQUESTED_API_VERSION = "1.7.36";
+    public static final String REQUESTED_API_VERSION = "2.0.3";
 
 
     /**


### PR DESCRIPTION
slf4j v2.0 series has been out since a few months and this change brings dialog up to date with the most recent stable 2.0.3 release.