### PR TITLE
Support custom output types and formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Added
+- Custom output writers and formatters can be used by providing a symbol for
+  the output's `:type` and `:format` keys. The symbol will be resolved to a var
+  at config time and called with the output map.
 
 
 ## [1.0.1] - 2022-06-01

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ its type keyword.
 
 #### Output Types
 
-There are four supported outputs:
+There are four built-in outputs:
 
 - `:null`
 
@@ -150,9 +150,14 @@ There are four supported outputs:
   `:level` event attributes as special fields, in addition to the formatted
   message.
 
+If you need an output that is not already provided, you can write your own by
+specifying a qualified symbol for the output `:type`. During initialization,
+this will be resolved to a var and called with the output map to construct the
+writer function. Check out the existing output types for examples.
+
 #### Message Formats
 
-There are four supported formats:
+There are four built-in formats:
 
 - `:message`
 
@@ -186,6 +191,11 @@ formatters will look for some additional metadata on events:
   to the message produced by the formatters.
 - If the event has `:dialog.format/extra`, it will also be printed as a data
   structure at the end of the message.
+
+Similar to the output writers, if you want more control over the format you can
+provide your own function by specifying a qualified symbol as the `:format`.
+This will be resolved to a var during initialization and called on events to
+produce the message string.
 
 
 ## License

--- a/src/clojure/dialog/config.clj
+++ b/src/clojure/dialog/config.clj
@@ -105,7 +105,7 @@
   [x constants]
   (or (fn? x)
       (var? x)
-      (symbol? x)
+      (qualified-symbol? x)
       (contains? constants x)))
 
 

--- a/src/clojure/dialog/config.clj
+++ b/src/clojure/dialog/config.clj
@@ -99,6 +99,16 @@
            env))))
 
 
+(defn- resolvable?
+  "True if the provided value can be resolved to a function by being a
+  reference or one of a set of known keywords."
+  [x constants]
+  (or (fn? x)
+      (var? x)
+      (symbol? x)
+      (contains? constants x)))
+
+
 (defn- resolve-fn
   "Safely resolve the given value to a function. Returns the function, or prints
   an error and returns nil."
@@ -164,21 +174,29 @@
 (defn- output-formatter
   "Construct an output formatting function."
   [output]
-  (case (:format output)
-    :message :message
-    :simple  (fmt.simple/formatter output)
-    :pretty  (fmt.pretty/formatter output)
-    :json    (fmt.json/formatter output)))
+  (let [fmt (:format output)]
+    (if (keyword? fmt)
+      (case fmt
+        :message :message
+        :simple  (fmt.simple/formatter output)
+        :pretty  (fmt.pretty/formatter output)
+        :json    (fmt.json/formatter output))
+      (let [constructor (resolve-fn "formatter constructor" fmt)]
+        (constructor output)))))
 
 
 (defn- output-writer
   "Construct an output writing function."
   [output]
-  (case (:type output)
-    :null   nil
-    :file   (out.file/writer output)
-    :print  (out.print/writer output)
-    :syslog (out.syslog/writer output)))
+  (let [typ (:type output)]
+    (if (keyword? typ)
+      (case (:type output)
+        :null   nil
+        :file   (out.file/writer output)
+        :print  (out.print/writer output)
+        :syslog (out.syslog/writer output))
+      (let [constructor (resolve-fn "output constructor" typ)]
+        (constructor output)))))
 
 
 (defn- initialize-output
@@ -202,16 +220,15 @@
                  (pr-str output))
 
       ;; Check that output type is understood.
-      (not (contains? #{:null :file :print :syslog}
-                      (:type output)))
+      (not (resolvable? (:type output) #{:null :file :print :syslog}))
       (print-err "output %s has invalid type: %s"
                  id
                  (:type output))
 
       ;; Check that format type is understood.
       (and (contains? output :format)
-           (not (contains? #{:message :simple :pretty :json}
-                           (:format output))))
+           (not (resolvable? (:format output)
+                             #{:message :simple :pretty :json})))
       (print-err "output %s has invalid format: %s"
                  id
                  (:format output))


### PR DESCRIPTION
Prompted by the question in #12, this PR adds support for custom symbols as the output `:type` and `:format` configuration. These symbols will be resolved to constructor functions during initialization and called on the output map to produce the writer and formatter functions.