### PR TITLE
Custom output levels

### DIFF
--- a/dev/dialog.edn
+++ b/dev/dialog.edn
@@ -49,7 +49,8 @@
            :main {:stdout {:type :print
                            :stream :stdout
                            :format :simple
-                           :padding false}
+                           :padding false
+                           :levels {"vault.client" :warn}}
                   :loggly {:type :syslog
                            :format :json
                            :middleware [acme.logging/filter-syslog]}}}}

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -157,3 +157,19 @@ Similar to the output writers, if you want more control over the format you can
 provide your own function by specifying a qualified symbol as the `:format`.
 This will be resolved to a var during initialization and called on events to
 produce the message string.
+
+### Output Levels
+
+If you need to override the global levels for events on specific outputs, you
+can provide the same `:level` and `:levels` settings [described above](#logger-levels).
+These will let you adjust the thresholds for events being written to each
+specific output, but note the following caveats:
+
+- You can only raise logger thresholds, not lower them - if an event is not
+  logged because it doesn't meet the global threshold for that logger, it will
+  never be sent to the outputs for evaluation.
+- Output levels do not have the same performance optimizations as the global
+  levels, because the results are not cached and the event has to have made it
+  from the SLF4J framework into a Clojure event map and handed to Dialog.
+- You cannot adjust output levels dynamically, short of reloading the whole
+  config. (This is why there is no `:blocked` equivalent.)

--- a/src/clojure/dialog/logger.clj
+++ b/src/clojure/dialog/logger.clj
@@ -110,12 +110,15 @@
 (defn- match-level
   "Get the value for the key which is the deepest prefix of the given logger
   name, or nil if no keys prefix the logger."
-  [logger]
-  (when-let [match (->> (:levels config)
-                        (sort-by (comp count key) (comp - compare))
-                        (filter #(prefixed? logger (key %)))
-                        (first))]
-    (val match)))
+  ([logger]
+   (match-level (:levels config) logger))
+  ([levels logger]
+   (when-let [match (and (seq levels)
+                         (->> levels
+                              (sort-by (comp count key) (comp - compare))
+                              (filter #(prefixed? logger (key %)))
+                              (first)))]
+     (val match))))
 
 
 (defn valid-level?
@@ -172,12 +175,18 @@
   (reset-level-cache!))
 
 
-(defn enabled?
-  "True if the given logger is enabled at the provided level."
-  [logger level]
+(defn level-allowed?
+  "True if the logger level meets or exceeds the threshold level."
+  [threshold level]
   (Level/isAllowed
-    (Level/ofKeyword (get-level logger))
+    (Level/ofKeyword threshold)
     (Level/ofKeyword level)))
+
+
+(defn enabled?
+  "True if the named logger is enabled at the provided event level."
+  [logger level]
+  (level-allowed? (get-level logger) level))
 
 
 ;; ## Event Logging
@@ -218,6 +227,13 @@
     middleware))
 
 
+(defn- get-output-level
+  "Determine the output-specific level threshold configured for a logger."
+  [output logger]
+  (or (match-level (:levels output) logger)
+      (:level output)))
+
+
 (defn- write-output!
   "Write an event to an output, applying any configured formatter."
   [id output event]
@@ -249,7 +265,10 @@
       (fn write-event
         [[id output]]
         (when-let [event (apply-middleware event (:middleware output))]
-          (write-output! id output event)))
+          (let [threshold (get-output-level output (:logger event))]
+            (when (or (nil? threshold)
+                      (level-allowed? threshold (:level event)))
+              (write-output! id output event)))))
       (:outputs config))))
 
 


### PR DESCRIPTION
This PR adds support for customized logger levels in outputs, similar to the addition of output-specific middleware. This seems like a common enough desire that the library can build it in, and this way we can provide guidance around the tradeoffs in the documentation. It also doesn't add much surface area to the library, since level filtering is already a core concern.

This is an alternative to #30 with fewer required changes since this makes it a native feature.