### PR TITLE
Update pretty dependencies (and other dependencies).

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,12 +4,12 @@
   "target/classes"]
 
  :deps
- {org.clojure/clojure {:mvn/version "1.11.1"}
-  org.clojure/data.json {:mvn/version "2.4.0"}
-  org.slf4j/slf4j-api {:mvn/version "2.0.7"}
-  org.slf4j/jul-to-slf4j {:mvn/version "2.0.7"}
-  org.slf4j/jcl-over-slf4j {:mvn/version "2.0.7"}
-  org.slf4j/log4j-over-slf4j {:mvn/version "2.0.7"}
+ {org.clojure/clojure {:mvn/version "1.12.3"}
+  org.clojure/data.json {:mvn/version "2.5.1"}
+  org.slf4j/slf4j-api {:mvn/version "2.0.17"}
+  org.slf4j/jul-to-slf4j {:mvn/version "2.0.17"}
+  org.slf4j/jcl-over-slf4j {:mvn/version "2.0.17"}
+  org.slf4j/log4j-over-slf4j {:mvn/version "2.0.17"}
   org.clj-commons/pretty {:mvn/version "3.6.7"}
   aero/aero {:mvn/version "1.1.6"}}
 
@@ -20,16 +20,16 @@
 
  :aliases
  {:build
-  {:deps {org.clojure/clojure {:mvn/version "1.11.1"}
-          org.slf4j/slf4j-api {:mvn/version "2.0.7"}
+  {:deps {org.clojure/clojure {:mvn/version "1.12.3"}
+          org.slf4j/slf4j-api {:mvn/version "2.0.17"}
           org.clojure/tools.build {:mvn/version "0.9.2"}
-          io.github.slipset/deps-deploy {:git/sha "fd8ff2de9c4bda82a1c69c387d56217473b394be"}}
+          io.github.slipset/deps-deploy {:git/sha "07022b92d768590ab25b9ceb619ef17d2922da9a"}}
    :ns-default build}
 
   :repl
   {:extra-paths ["dev" "test"]
-   :extra-deps {org.clojure/tools.logging {:mvn/version "1.2.4"}
-                org.clojure/tools.namespace {:mvn/version "1.4.4"}
+   :extra-deps {org.clojure/tools.logging {:mvn/version "1.3.0"}
+                org.clojure/tools.namespace {:mvn/version "1.5.0"}
                 criterium/criterium {:mvn/version "0.4.6"}
                 mvxcvi/puget {:mvn/version "1.3.4"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
@@ -38,12 +38,12 @@
                "-e" "(clojure.main/repl,:init,#(do,(require,'dialog.repl),(in-ns,'dialog.repl)),:print,puget.printer/cprint)"]}
 
   :check
-  {:extra-deps {io.github.athos/clj-check {:git/sha "0ca84df1357d71429243b99908303f45a934654c"}}
+  {:extra-deps {io.github.athos/clj-check {:git/sha "d997df866b2a04b7ce7b17533093ee0a2e2cb729"}}
    :main-opts ["-m" "clj-check.check" "src/clojure"]}
 
   :test
   {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.80.1274"}}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
               "-Duser.language=en"
               "-Duser.country=US"]

--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
   org.slf4j/jul-to-slf4j {:mvn/version "2.0.7"}
   org.slf4j/jcl-over-slf4j {:mvn/version "2.0.7"}
   org.slf4j/log4j-over-slf4j {:mvn/version "2.0.7"}
-  io.aviso/pretty {:mvn/version "1.3"}
+  org.clj-commons/pretty {:mvn/version "3.6.7"}
   aero/aero {:mvn/version "1.1.6"}}
 
  :deps/prep-lib

--- a/src/clojure/dialog/format/json.clj
+++ b/src/clojure/dialog/format/json.clj
@@ -1,8 +1,8 @@
 (ns dialog.format.json
   "Log format which presents events as JSON objects for structured logging."
   (:require
-    [clojure.data.json :as json]
-    [io.aviso.exception :as ex]))
+    [clj-commons.format.exceptions :as ex]
+    [clojure.data.json :as json]))
 
 
 (defn- key-fn

--- a/src/clojure/dialog/format/pretty.clj
+++ b/src/clojure/dialog/format/pretty.clj
@@ -2,9 +2,10 @@
   "Log format which presents events in ANSI-colored text, suitable for human
   consumption in a REPL console."
   (:require
+    [clj-commons.ansi :as ansi]
+    [clj-commons.format.exceptions :as ex]
     [clojure.string :as str]
-    [io.aviso.ansi :as ansi]
-    [io.aviso.exception :as ex])
+    [dialog.util :as util])
   (:import
     (java.time
       LocalDateTime
@@ -35,7 +36,7 @@
   "Pad a string on the right with spaces to make it fit a certain visual width."
   [string width]
   (if (pos-int? width)
-    (let [vlen (ansi/visual-length string)]
+    (let [vlen (util/visual-length string)]
       (if (<= width vlen)
         string
         (apply str string (repeat (- width vlen) " "))))
@@ -61,12 +62,12 @@
   "Format a thread name for printing."
   [thread]
   (str "["
-       (ansi/green
-         (if thread
-           (if (str/starts-with? (str/lower-case thread) "nrepl-session-")
-             "nREPL"
-             thread)
-           "-"))
+       (ansi/compose [:green
+                      (if thread
+                        (if (str/starts-with? (str/lower-case thread) "nrepl-session-")
+                          "nREPL"
+                          thread)
+                        "-")])
        "]"))
 
 
@@ -75,41 +76,41 @@
   [level]
   (let [level-str (str/upper-case (name level))]
     (case level
-      :fatal (ansi/bold-magenta level-str)
-      :error (ansi/bold-red level-str)
-      :warn (ansi/red level-str)
-      :info (ansi/blue level-str)
+      :fatal (ansi/compose [:bold.magenta level-str])
+      :error (ansi/compose [:bold.red] level-str)
+      :warn (ansi/compose [:red level-str])
+      :info (ansi/compose [:blue level-str])
       level-str)))
 
 
 (defn- format-logger
   "Format a logger name to fit within the desired max length."
   [logger max-length]
-  (ansi/cyan
-    (cond
-      ;; Don't do trimming
-      (not (pos-int? max-length))
-      logger
+  (ansi/compose [:cyan
+                 (cond
+                   ;; Don't do trimming
+                   (not (pos-int? max-length))
+                   logger
 
-      ;; Logger name fits in limit
-      (<= (count logger) max-length)
-      logger
+                   ;; Logger name fits in limit
+                   (<= (count logger) max-length)
+                   logger
 
-      ;; Collapse logger segments
-      :else
-      (loop [collapsed []
-             parts (str/split logger #"\.")]
-        (let [candidate (str/join "." (concat collapsed parts))]
-          (if (< max-length (count candidate))
-            ;; Need to trim more.
-            (if-let [next-part (first parts)]
-              ;; Collapse next part in the ns into a single character.
-              (recur (conj collapsed (subs next-part 0 1))
-                     (rest parts))
-              ;; No more parts, just truncate it.
-              (subs candidate 0 max-length))
-            ;; Abbreviated logger fits within limit.
-            candidate))))))
+                   ;; Collapse logger segments
+                   :else
+                   (loop [collapsed []
+                          parts (str/split logger #"\.")]
+                     (let [candidate (str/join "." (concat collapsed parts))]
+                       (if (< max-length (count candidate))
+                         ;; Need to trim more.
+                         (if-let [next-part (first parts)]
+                           ;; Collapse next part in the ns into a single character.
+                           (recur (conj collapsed (subs next-part 0 1))
+                                  (rest parts))
+                           ;; No more parts, just truncate it.
+                           (subs candidate 0 max-length))
+                         ;; Abbreviated logger fits within limit.
+                         candidate))))]))
 
 
 (defn formatter
@@ -158,7 +159,7 @@
           (str " " tail))
         ;; Extra Data
         (when-let [extra (:dialog.format/extra (meta event))]
-          (str "  " (ansi/cyan (pr-str extra))))
+          (str "  " (ansi/compose [:cyan (pr-str extra)])))
         ;; Exceptions
         (when-let [ex (:error event)]
           (str "\n" (ex/format-exception ex)))))))

--- a/src/clojure/dialog/util.clj
+++ b/src/clojure/dialog/util.clj
@@ -1,5 +1,7 @@
 (ns ^:no-doc dialog.util
   "Implementation utilities."
+  (:require
+    [clojure.string :as str])
   (:import
     java.net.InetAddress))
 
@@ -93,3 +95,18 @@
                          "localhost"))]
         (reset! hostname-ref hostname)
         hostname)))
+
+
+(def ^:const ^:private ansi-pattern #"\e\[.*?m")
+
+
+(defn strip-ansi
+  "Removes ANSI codes from a string, returning just the raw text."
+  ^String [string]
+  (str/replace string ansi-pattern ""))
+
+
+(defn visual-length
+  "Returns the length of the string, with ANSI codes stripped out."
+  [string]
+  (-> string strip-ansi .length))

--- a/src/java/dialog/impl/DialogServiceProvider.java
+++ b/src/java/dialog/impl/DialogServiceProvider.java
@@ -20,7 +20,7 @@ public class DialogServiceProvider implements SLF4JServiceProvider {
      * The value of this field is modified with each major release.
      */
     // to avoid constant folding by the compiler, this field must *not* be final
-    public static String REQUESTED_API_VERSION = "2.0.7"; // !final
+    public static String REQUESTED_API_VERSION = "2.0.17"; // !final
 
     private ILoggerFactory loggerFactory;
     private IMarkerFactory markerFactory;

--- a/test/dialog/format/pretty_test.clj
+++ b/test/dialog/format/pretty_test.clj
@@ -3,7 +3,7 @@
     [clojure.string :as str]
     [clojure.test :refer [deftest testing is]]
     [dialog.format.pretty :as pretty]
-    [io.aviso.ansi :as ansi])
+    [dialog.util :as util])
   (:import
     java.time.Instant))
 
@@ -23,14 +23,14 @@
 
 
 (deftest thread-formatting
-  (let [format-thread (comp ansi/strip-ansi #'pretty/format-thread)]
+  (let [format-thread (comp util/strip-ansi #'pretty/format-thread)]
     (is (= "[-]" (format-thread nil)))
     (is (= "[main]" (format-thread "main")))
     (is (= "[nREPL]" (format-thread "nREPL-session-1234-5678-90ab")))))
 
 
 (deftest level-formatting
-  (let [format-level (comp ansi/strip-ansi #'pretty/format-level)]
+  (let [format-level (comp util/strip-ansi #'pretty/format-level)]
     (is (= "TRACE" (format-level :trace)))
     (is (= "DEBUG" (format-level :debug)))
     (is (= "INFO"  (format-level :info)))
@@ -40,7 +40,7 @@
 
 
 (deftest logger-formatting
-  (let [format-logger (comp ansi/strip-ansi #'pretty/format-logger)]
+  (let [format-logger (comp util/strip-ansi #'pretty/format-logger)]
     (is (= "one" (format-logger "one" 30)))
     (is (= "one" (format-logger "one" 3)))
     (is (= "o" (format-logger "one" 2)))
@@ -52,7 +52,7 @@
 
 
 (deftest message-formatting
-  (let [fmt (comp ansi/strip-ansi (pretty/formatter {}))
+  (let [fmt (comp util/strip-ansi (pretty/formatter {}))
         inst (Instant/parse "2021-12-27T15:33:18Z")]
     (testing "basic format"
       (is (= "2021-12-27T15:33:18Z [thread-pool-123]        INFO  foo.bar.baz                     Hello, logger!"
@@ -106,7 +106,7 @@
                           :error ex})]
         (is (str/includes? message "java.lang.RuntimeException: BOOM"))))
     (testing "with custom padding"
-      (let [fmt (comp ansi/strip-ansi (pretty/formatter {:padding {:thread 10, :logger 15}}))]
+      (let [fmt (comp util/strip-ansi (pretty/formatter {:padding {:thread 10, :logger 15}}))]
         (is (= "2021-12-27T15:33:18Z [main]     INFO  acme.main        Hello, logger!"
                (fmt {:time inst
                      :level :info
@@ -114,7 +114,7 @@
                      :message "Hello, logger!"
                      :thread "main"})))))
     (testing "without padding"
-      (let [fmt (comp ansi/strip-ansi (pretty/formatter {:padding false}))]
+      (let [fmt (comp util/strip-ansi (pretty/formatter {:padding false}))]
         (is (= "2021-12-27T15:33:18Z [thread-pool-123] INFO foo.bar.baz  Hello, logger!"
                (fmt {:time inst
                      :level :info

--- a/test/dialog/format/simple_test.clj
+++ b/test/dialog/format/simple_test.clj
@@ -3,7 +3,7 @@
     [clojure.string :as str]
     [clojure.test :refer [deftest testing is]]
     [dialog.format.simple :as simple]
-    [io.aviso.ansi :as ansi])
+    [dialog.util :as util])
   (:import
     java.time.Instant))
 
@@ -74,7 +74,7 @@
           "custom extra info shows"))
     (testing "throwables"
       (let [ex (RuntimeException. "BOOM")
-            message (ansi/strip-ansi
+            message (util/strip-ansi
                       (fmt {:level :error
                             :logger "foo.bar.baz"
                             :error ex}))]


### PR DESCRIPTION
The pretty library was moved to clj-commons and had some breaking changes. This updates to the latest version and adjusts the use to match the new APIs. A couple of helpers that are no longer available in the library got moved to dialog.util namespace as part of this.

As a follow up I also bumped all other dependencies (requiring no code changes).