### PR TITLE
Add default handler for non-JSON-serializable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Changed
+- The `:json` formatter now handles objects that aren't JSON serializiable
+  by calling `clojure.core/str` on them and writing the resulting string.
+  Previously, these values would cause the event to be dropped with a warning similar to
+  `[dialog output error] Failed to write to output stdout: Don't know how to write JSON of class <class>`.
+- Update `clojure.data.json` dependency.
 
 
 ## [2.0.115] - 2023-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- The `:json` formatter now handles objects that aren't JSON serializiable
+- The `:json` formatter now handles objects that aren't JSON serializable
   by calling `clojure.core/str` on them and writing the resulting string.
   Previously, these values would cause the event to be dropped with a warning similar to
   `[dialog output error] Failed to write to output stdout: Don't know how to write JSON of class <class>`.

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"}
-  org.clojure/data.json {:mvn/version "2.4.0"}
+  org.clojure/data.json {:mvn/version "2.5.1"}
   org.slf4j/slf4j-api {:mvn/version "2.0.7"}
   org.slf4j/jul-to-slf4j {:mvn/version "2.0.7"}
   org.slf4j/jcl-over-slf4j {:mvn/version "2.0.7"}
@@ -43,7 +43,8 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.80.1274"}}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.80.1274"}
+                clj-time/clj-time {:mvn/version "0.15.2"}}
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
               "-Duser.language=en"
               "-Duser.country=US"]

--- a/deps.edn
+++ b/deps.edn
@@ -52,7 +52,8 @@
 
   :coverage
   {:extra-paths ["test"]
-   :extra-deps {cloverage/cloverage {:mvn/version "RELEASE"}}
+   :extra-deps {cloverage/cloverage {:mvn/version "RELEASE"}
+                clj-time/clj-time {:mvn/version "0.15.2"}}
    :jvm-opts ["-Duser.language=en"
               "-Duser.country=US"]
    :main-opts ["-m" "cloverage.coverage"

--- a/src/clojure/dialog/format/json.clj
+++ b/src/clojure/dialog/format/json.clj
@@ -75,6 +75,14 @@
      (str v))))
 
 
+(defn- default-write-fn
+  "Default write handler for any types that don't implement
+  `clojure.data.json/JSONWriter`: just calls `str` on the value and writes the
+  resulting string."
+  [value out options]
+  (json/-write (str value) out options))
+
+
 (defn formatter
   "Construct a JSON event formatting function."
   [_output]
@@ -84,4 +92,5 @@
       event
       :key-fn key-fn
       :value-fn value-fn
+      :default-write-fn default-write-fn
       :escape-slash false)))

--- a/test/dialog/format/json_test.clj
+++ b/test/dialog/format/json_test.clj
@@ -1,8 +1,8 @@
 (ns dialog.format.json-test
   (:require
+    [clj-time.core :as time]
     [clojure.string :as str]
     [clojure.test :refer [deftest testing is]]
-    [clj-time.core :as time]
     [dialog.format.json :as json])
   (:import
     java.time.Instant))
@@ -50,6 +50,6 @@
             event {:date-time date-time}]
         (with-redefs [json/default-write-fn (fn [& _] (throw (Exception. "default-write-fn called")))]
           (is (thrown? Exception #"^default-write-fn called$"
-                (fmt event))))
+                       (fmt event))))
         (is (= "{\"date-time\":\"2025-05-05T00:00:00.000Z\"}"
                (fmt {:date-time date-time})))))))

--- a/test/dialog/format/json_test.clj
+++ b/test/dialog/format/json_test.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as str]
     [clojure.test :refer [deftest testing is]]
+    [clj-time.core :as time]
     [dialog.format.json :as json])
   (:import
     java.time.Instant))
@@ -43,4 +44,12 @@
     (testing "throwables"
       (let [ex (RuntimeException. "BOOM")
             message (fmt {:error ex})]
-        (is (str/starts-with? message "{\"error\":[{\"class-name\":\"java.lang.RuntimeException\","))))))
+        (is (str/starts-with? message "{\"error\":[{\"class-name\":\"java.lang.RuntimeException\","))))
+    (testing "types that don't implement JSONWriter"
+      (let [date-time (time/date-time 2025 5 5)
+            event {:date-time date-time}]
+        (with-redefs [json/default-write-fn (fn [& _] (throw (Exception. "default-write-fn called")))]
+          (is (thrown? Exception #"^default-write-fn called$"
+                (fmt event))))
+        (is (= "{\"date-time\":\"2025-05-05T00:00:00.000Z\"}"
+               (fmt {:date-time date-time})))))))


### PR DESCRIPTION
With this PR, the `:json` formatter now handles objects that aren't JSON serializable by calling `clojure.core/str` on them and writing the resulting string. Previously, these values would cause the event to be dropped with a warning similar to:


```
[dialog output error] Failed to write to output stdout: Don't know how to write JSON of class <class>
```

I updated the `clojure.data.json` dependency to the latest version to pick up the new `:default-write-fn` option used to implement this.